### PR TITLE
[Feature request] Support regex when `ShouldGenerate.contains` is `true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.4
+
+- Support regex when `ShouldGenerate.contains` is `true`.
+
 ## 1.0.3
 
 - Support the latest `package:analyzer`.

--- a/lib/src/test_annotated_classes.dart
+++ b/lib/src/test_annotated_classes.dart
@@ -244,7 +244,7 @@ class AnnotatedTest<T> {
       expect(
         output,
         exp.contains
-            ? contains(exp.expectedOutput)
+            ? contains(RegExp(exp.expectedOutput))
             : equals(exp.expectedOutput),
       );
     } on TestFailure {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen_test
-version: 1.0.3
+version: 1.0.4
 description: >-
   Test support for the source_gen package.
   Includes helpers to make it easy to validate both success and failure cases.

--- a/test/regex_test.dart
+++ b/test/regex_test.dart
@@ -1,0 +1,18 @@
+import 'package:source_gen_test/src/build_log_tracking.dart';
+import 'package:source_gen_test/src/init_library_reader.dart';
+import 'package:source_gen_test/src/test_annotated_classes.dart';
+
+import 'src/test_annotation.dart';
+import 'test_generator.dart';
+
+Future<void> main() async {
+  initializeBuildLogTracking();
+  final reader = await initializeLibraryReaderForDirectory(
+    'test/src',
+    'test_regex.dart',
+  );
+  testAnnotatedElements<TestAnnotation>(
+    reader,
+    const TestGenerator(),
+  );
+}

--- a/test/src/test_regex.dart
+++ b/test/src/test_regex.dart
@@ -1,0 +1,14 @@
+import 'package:source_gen_test/annotations.dart';
+
+import 'test_annotation.dart';
+
+@ShouldGenerate(
+  r'''
+const [A-Z]{1}[a-zA-Z]*NameLength = \d+;
+
+const [A-Z]{1}[a-zA-Z]*NameLowerCase = [a-z]+;
+''',
+  contains: true,
+)
+@TestAnnotation()
+class TestClass {}


### PR DESCRIPTION
Thanks for the great tool!

I submitted this pull request because there was a case where I wanted to use regex in `ShouldGenerate.expectedOutput`.

I would appreciate it if you could review it and release it if you would like.