### PR TITLE
fix: add missing clearLogBuilds

### DIFF
--- a/lib/src/build_log_tracking.dart
+++ b/lib/src/build_log_tracking.dart
@@ -33,6 +33,7 @@ void initializeBuildLogTracking() {
   });
 
   tearDown(() async {
+    clearBuildLog();
     if (logSubscription != null) {
       await logSubscription!.cancel();
       logSubscription = null;

--- a/lib/src/test_annotated_classes.dart
+++ b/lib/src/test_annotated_classes.dart
@@ -249,6 +249,7 @@ class AnnotatedTest<T> {
       );
     } on TestFailure {
       printOnFailure("ACTUAL CONTENT:\nr'''\n$output'''");
+      clearBuildLog();
       rethrow;
     }
 


### PR DESCRIPTION
## Problem

Some tests keep failing with such error:
```
`buildLogItems` is not empty. Tests should validate the contents of `buildLogItems` and call `clearBuildLog` before `tearDown`.
```
even after they are fixed and relaunched.

## Solution

I've just added `clearBuildLog` in two places:
- after `TestFailure` detection;
- at the very start of `tearDown`.