### PR TITLE
Fixes for build_test 3.0.0.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         # Add macos-latest and/or windows-latest if relevant for this package.
         os: [ubuntu-latest]
-        sdk: [3.4, dev]
+        sdk: [3.7, dev]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
-## 1.1.2-wip
+## 1.2.0
 
-- Fixed some doc comment references.
+- Require `build: ^2.5.0`.
+- Require `build_test: ^3.2.0`.
 - Require `sdk: ^3.7.0`
+- Fixed some doc comment references.
 
 ## 1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.1.2-wip
 
 - Fixed some doc comment references.
+- Require `sdk: ^3.7.0`
 
 ## 1.1.1
 

--- a/example/example_generator.dart
+++ b/example/example_generator.dart
@@ -7,9 +7,7 @@ import 'src/example_annotation.dart';
 class ExampleGenerator extends GeneratorForAnnotation<ExampleAnnotation> {
   final bool requireTestClassPrefix;
 
-  const ExampleGenerator({
-    this.requireTestClassPrefix = true,
-  });
+  const ExampleGenerator({this.requireTestClassPrefix = true});
 
   @override
   Iterable<String> generateForAnnotatedElement(

--- a/lib/src/annotations.dart
+++ b/lib/src/annotations.dart
@@ -9,7 +9,7 @@ abstract class TestExpectation {
   final List<String> expectedLogItems;
 
   const TestExpectation._(this.configurations, List<String>? expectedLogItems)
-      : expectedLogItems = expectedLogItems ?? const [];
+    : expectedLogItems = expectedLogItems ?? const [];
 
   TestExpectation replaceConfiguration(Iterable<String> newConfiguration);
 }
@@ -74,11 +74,11 @@ class ShouldGenerateFile extends TestExpectation {
     this.partOfCurrent = false,
     Iterable<String>? configurations,
     List<String>? expectedLogItems,
-  })  : assert(
-          partOf == null || !partOfCurrent,
-          'Cannot have both partOf and partOfCurrent',
-        ),
-        super._(configurations, expectedLogItems);
+  }) : assert(
+         partOf == null || !partOfCurrent,
+         'Cannot have both partOf and partOfCurrent',
+       ),
+       super._(configurations, expectedLogItems);
 
   @override
   TestExpectation replaceConfiguration(Iterable<String> newConfiguration) =>
@@ -118,8 +118,8 @@ class ShouldThrow extends TestExpectation {
     Object? element = true,
     Iterable<String>? configurations,
     List<String>? expectedLogItems,
-  })  : element = element ?? true,
-        super._(configurations, expectedLogItems);
+  }) : element = element ?? true,
+       super._(configurations, expectedLogItems);
 
   @override
   TestExpectation replaceConfiguration(Iterable<String> newConfiguration) =>

--- a/lib/src/expectation_element.dart
+++ b/lib/src/expectation_element.dart
@@ -10,9 +10,8 @@ List<ExpectationElement> genAnnotatedElements(
   Set<String> configDefaults,
 ) {
   final allElements = libraryReader.allElements
-      .where((element) => element.name != null)
-      .toList(growable: false)
-    ..sort((a, b) => a.name!.compareTo(b.name!));
+    .where((element) => element.name != null)
+    .toList(growable: false)..sort((a, b) => a.name!.compareTo(b.name!));
 
   return allElements.expand((element) {
     final initialValues = _expectationElements(element).toList();
@@ -21,9 +20,10 @@ List<ExpectationElement> genAnnotatedElements(
 
     final duplicateConfigs = <String>{};
 
-    for (var configs in initialValues
-        .map((e) => e.configurations)
-        .whereType<Iterable<String>>()) {
+    for (var configs
+        in initialValues
+            .map((e) => e.configurations)
+            .whereType<Iterable<String>>()) {
       if (configs.isEmpty) {
         throw InvalidGenerationSourceError(
           '`configuration` cannot be empty.',
@@ -123,11 +123,12 @@ ShouldThrow _shouldThrow(DartObject obj) {
   );
 }
 
-List<String> _expectedLogItems(ConstantReader reader) => reader
-    .read('expectedLogItems')
-    .listValue
-    .map((obj) => obj.toStringValue()!)
-    .toList();
+List<String> _expectedLogItems(ConstantReader reader) =>
+    reader
+        .read('expectedLogItems')
+        .listValue
+        .map((obj) => obj.toStringValue()!)
+        .toList();
 
 Set<String>? _configurations(ConstantReader reader) {
   final field = reader.read('configurations');

--- a/lib/src/generate_for_element.dart
+++ b/lib/src/generate_for_element.dart
@@ -47,19 +47,20 @@ Future<String> generateForElement<T>(
   var annotation = generator.typeChecker.firstAnnotationOf(element);
 
   if (annotation == null) {
-    final annotationFromTestLib = element.metadata
-        .map((ea) => ea.computeConstantValue()!)
-        .where((obj) {
-          if (obj.type is InterfaceType) {
-            final uri = (obj.type as InterfaceType).element.source.uri;
-            return uri.isScheme('package') &&
-                uri.pathSegments.first == testPackageName;
-          }
+    final annotationFromTestLib =
+        element.metadata
+            .map((ea) => ea.computeConstantValue()!)
+            .where((obj) {
+              if (obj.type is InterfaceType) {
+                final uri = (obj.type as InterfaceType).element.source.uri;
+                return uri.isScheme('package') &&
+                    uri.pathSegments.first == testPackageName;
+              }
 
-          return false;
-        })
-        .where((obj) => obj.type!.element!.name == T.toString())
-        .toList();
+              return false;
+            })
+            .where((obj) => obj.type!.element!.name == T.toString())
+            .toList();
 
     String msg;
     if (annotationFromTestLib.length == 1) {

--- a/lib/src/generate_for_element.dart
+++ b/lib/src/generate_for_element.dart
@@ -99,7 +99,6 @@ Future<String> generateForElement<T>(
   return formatter.format(generated);
 }
 
-// ignore: subtype_of_sealed_class
 class _MockBuildStep extends BuildStep {
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/lib/src/init_library_reader.dart
+++ b/lib/src/init_library_reader.dart
@@ -16,10 +16,9 @@ Future<PathAwareLibraryReader> initializeLibraryReaderForDirectory(
   String targetLibraryFileName,
 ) async {
   final map = Map.fromEntries(
-    Directory(sourceDirectory)
-        .listSync()
-        .whereType<File>()
-        .map((f) => MapEntry(p.basename(f.path), f.readAsStringSync())),
+    Directory(sourceDirectory).listSync().whereType<File>().map(
+      (f) => MapEntry(p.basename(f.path), f.readAsStringSync()),
+    ),
   );
 
   try {
@@ -64,8 +63,9 @@ Future<LibraryReader> initializeLibraryReader(
 
   final targetLibraryAssetId = assetIdForFile(targetLibraryFileName);
 
-  final assetMap = contentMap
-      .map((file, content) => MapEntry(assetIdForFile(file), content));
+  final assetMap = contentMap.map(
+    (file, content) => MapEntry(assetIdForFile(file), content),
+  );
 
   final library = await resolveSources(
     assetMap,

--- a/lib/src/init_library_reader.dart
+++ b/lib/src/init_library_reader.dart
@@ -74,6 +74,7 @@ Future<LibraryReader> initializeLibraryReader(
       return item.libraryFor(assetId);
     },
     resolverFor: targetLibraryAssetId,
+    readAllSourcesFromFilesystem: true,
   );
 
   return LibraryReader(library);

--- a/lib/src/matchers.dart
+++ b/lib/src/matchers.dart
@@ -10,8 +10,11 @@ Matcher throwsInvalidGenerationSourceError(
   Object? todoMatcher,
   Object? elementMatcher,
 }) {
-  var matcher = const TypeMatcher<InvalidGenerationSource>()
-      .having((e) => e.message, 'message', messageMatcher);
+  var matcher = const TypeMatcher<InvalidGenerationSource>().having(
+    (e) => e.message,
+    'message',
+    messageMatcher,
+  );
 
   if (elementMatcher != null) {
     matcher = matcher.having((e) => e.element, 'element', elementMatcher);

--- a/lib/src/test_annotated_classes.dart
+++ b/lib/src/test_annotated_classes.dart
@@ -104,13 +104,16 @@ List<AnnotatedTest<T>> getAnnotatedClasses<T>(
     defaultConfigSet = generators.keys.toSet();
   }
 
-  final annotatedElements =
-      genAnnotatedElements(libraryReader, defaultConfigSet);
+  final annotatedElements = genAnnotatedElements(
+    libraryReader,
+    defaultConfigSet,
+  );
 
   final unusedConfigurations = generators.keys.toSet();
   for (var annotatedElement in annotatedElements) {
-    unusedConfigurations
-        .removeAll(annotatedElement.expectation.configurations!);
+    unusedConfigurations.removeAll(
+      annotatedElement.expectation.configurations!,
+    );
   }
   if (unusedConfigurations.isNotEmpty) {
     if (unusedConfigurations.contains(_defaultConfigurationName)) {
@@ -184,14 +187,18 @@ List<AnnotatedTest<T>> getAnnotatedClasses<T>(
   }
 
   if (mapMissingConfigs.isNotEmpty) {
-    final elements = mapMissingConfigs.entries.toList()
-      ..sort((a, b) => a.key.compareTo(b.key));
+    final elements =
+        mapMissingConfigs.entries.toList()
+          ..sort((a, b) => a.key.compareTo(b.key));
 
-    final message = elements.map((e) {
-      final sortedConfigs =
-          (e.value.toList()..sort()).map((v) => '"$v"').join(', ');
-      return '`${e.key}`: $sortedConfigs';
-    }).join('; ');
+    final message = elements
+        .map((e) {
+          final sortedConfigs = (e.value.toList()..sort())
+              .map((v) => '"$v"')
+              .join(', ');
+          return '`${e.key}`: $sortedConfigs';
+        })
+        .join('; ');
 
     throw ArgumentError(
       'There are elements defined with configurations with no associated '
@@ -288,10 +295,7 @@ class AnnotatedTest<T> {
         File(path).writeAsStringSync(testOutput);
       } else {
         final content = File(path).readAsStringSync();
-        expect(
-          testOutput,
-          exp.contains ? contains(content) : equals(content),
-        );
+        expect(testOutput, exp.contains ? contains(content) : equals(content));
       }
     } on FileSystemException catch (ex) {
       throw TestFailure(
@@ -331,10 +335,7 @@ class AnnotatedTest<T> {
       final outputDirectory =
           File(p.join(reader.directory, exp.expectedOutputFileName)).parent;
 
-      final path = p.relative(
-        reader.path,
-        from: outputDirectory.path,
-      );
+      final path = p.relative(reader.path, from: outputDirectory.path);
       return "part of '$path';\n\n$output";
     }
 
@@ -355,8 +356,11 @@ class AnnotatedTest<T> {
         expectedElementName = exp.element as String;
       }
       // ignore: deprecated_member_use
-      elementMatcher = const TypeMatcher<Element>()
-          .having((e) => e.name, 'name', expectedElementName);
+      elementMatcher = const TypeMatcher<Element>().having(
+        (e) => e.name,
+        'name',
+        expectedElementName,
+      );
     } else if (exp.element == true) {
       elementMatcher = isNotNull;
     } else {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
 repository: https://github.com/kevmoo/source_gen_test
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.7.0
 
 dependencies:
   analyzer: ">=6.5.0 <8.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_gen_test
-version: 1.1.2-wip
+version: 1.2.0
 description: >-
   Test support for the source_gen package.
   Includes helpers to make it easy to validate both success and failure cases.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 
 dependencies:
   analyzer: ">=6.5.0 <8.0.0"
-  build: ^2.4.1
-  build_test: ^2.1.7
+  build: ^2.5.0
+  build_test: ^3.2.0
   dart_style: '>=2.3.7 <4.0.0'
   meta: ^1.15.0
   path: ^1.9.0

--- a/test/generate_for_element_test.dart
+++ b/test/generate_for_element_test.dart
@@ -15,9 +15,8 @@ class TestAnnotation {
 Future<void> main() async {
   group('Bad annotations', () {
     test('duplicate configurations for the same member', () async {
-      final badReader = await initializeLibraryReader(
-        {
-          'bad_lib.dart': r"""
+      final badReader = await initializeLibraryReader({
+        'bad_lib.dart': r"""
 import 'package:source_gen_test/annotations.dart';
 import 'annotations.dart';
 @ShouldGenerate('', configurations: ['c'])
@@ -25,10 +24,8 @@ import 'annotations.dart';
 @TestAnnotation()
 class TestClass{}
 """,
-          'annotations.dart': _testAnnotationContent,
-        },
-        'bad_lib.dart',
-      );
+        'annotations.dart': _testAnnotationContent,
+      }, 'bad_lib.dart');
 
       expect(
         () => testAnnotatedElements(badReader, const TestGenerator()),
@@ -41,19 +38,16 @@ class TestClass{}
     });
 
     test('annotation with no configuration', () async {
-      final badReader = await initializeLibraryReader(
-        {
-          'bad_lib.dart': r"""
+      final badReader = await initializeLibraryReader({
+        'bad_lib.dart': r"""
 import 'package:source_gen_test/annotations.dart';
 import 'annotations.dart';
 @ShouldGenerate('', configurations: [])
 @TestAnnotation()
 class EmptyConfig{}
 """,
-          'annotations.dart': _testAnnotationContent,
-        },
-        'bad_lib.dart',
-      );
+        'annotations.dart': _testAnnotationContent,
+      }, 'bad_lib.dart');
 
       expect(
         () => testAnnotatedElements(badReader, const TestGenerator()),
@@ -72,31 +66,31 @@ class EmptyConfig{}
 
   group('generateForElement', () {
     test('TestClass1', () async {
-      final output =
-          await generateForElement(const TestGenerator(), reader, 'TestClass1');
+      final output = await generateForElement(
+        const TestGenerator(),
+        reader,
+        'TestClass1',
+      );
       printOnFailure(output);
-      expect(
-        output,
-        r'''
+      expect(output, r'''
 const TestClass1NameLength = 10;
 
 const TestClass1NameLowerCase = 'testclass1';
-''',
-      );
+''');
     });
 
     test('TestClass2', () async {
-      final output =
-          await generateForElement(const TestGenerator(), reader, 'TestClass2');
+      final output = await generateForElement(
+        const TestGenerator(),
+        reader,
+        'TestClass2',
+      );
       printOnFailure(output);
-      expect(
-        output,
-        r'''
+      expect(output, r'''
 const TestClass2NameLength = 10;
 
 const TestClass2NameLowerCase = 'testclass2';
-''',
-      );
+''');
     });
   });
 
@@ -205,10 +199,7 @@ const TestClass2NameLowerCase = 'testclass2';
             additionalGenerators: validAdditionalGenerators,
             defaultConfiguration: [],
           ),
-          _throwsArgumentError(
-            'Cannot be empty.',
-            'defaultConfiguration',
-          ),
+          _throwsArgumentError('Cannot be empty.', 'defaultConfiguration'),
         );
       });
 
@@ -218,8 +209,9 @@ const TestClass2NameLowerCase = 'testclass2';
             reader,
             const TestGenerator(),
             additionalGenerators: const {
-              'no-prefix-required':
-                  TestGenerator(requireTestClassPrefix: false),
+              'no-prefix-required': TestGenerator(
+                requireTestClassPrefix: false,
+              ),
             },
             defaultConfiguration: ['unknown'],
           ),
@@ -257,10 +249,7 @@ const TestClass2NameLowerCase = 'testclass2';
           () => testAnnotatedElements(
             reader,
             const TestGenerator(),
-            expectedAnnotatedTests: [
-              'TestClass1',
-              'TestClass2',
-            ],
+            expectedAnnotatedTests: ['TestClass1', 'TestClass2'],
           ),
           _throwsArgumentError(
             'There are items missing',
@@ -300,10 +289,7 @@ const TestClass2NameLowerCase = 'testclass2';
 
       test('missing a specified generator fails', () {
         expect(
-          () => testAnnotatedElements(
-            reader,
-            const TestGenerator(),
-          ),
+          () => testAnnotatedElements(reader, const TestGenerator()),
           _throwsArgumentError(
             'There are elements defined with configurations with no '
             'associated generator provided.\n'
@@ -355,7 +341,7 @@ const TestClass2NameLowerCase = 'testclass2';
 }
 
 Matcher _throwsArgumentError(Object? matcher, [String? name]) => throwsA(
-      isArgumentError
-          .having((e) => e.message, 'message', matcher)
-          .having((ae) => ae.name, 'name', name),
-    );
+  isArgumentError
+      .having((e) => e.message, 'message', matcher)
+      .having((ae) => ae.name, 'name', name),
+);

--- a/test/src/test_library.dart
+++ b/test/src/test_library.dart
@@ -13,11 +13,7 @@ const TestClass1NameLowerCase = 'testclass1';
 ''',
   configurations: ['default', 'no-prefix-required'],
 )
-@ShouldThrow(
-  'Uh...',
-  configurations: ['vague'],
-  element: false,
-)
+@ShouldThrow('Uh...', configurations: ['vague'], element: false)
 @TestAnnotation()
 class TestClass1 {}
 
@@ -25,11 +21,7 @@ class TestClass1 {}
   'goldens/test_library_file_no_part.dart',
   configurations: ['default', 'no-prefix-required'],
 )
-@ShouldThrow(
-  'Uh...',
-  configurations: ['vague'],
-  element: false,
-)
+@ShouldThrow('Uh...', configurations: ['vague'], element: false)
 @TestAnnotation()
 class TestClassFileNoPart {}
 
@@ -38,11 +30,7 @@ class TestClassFileNoPart {}
   partOf: 'test_part_owner.dart',
   configurations: ['default', 'no-prefix-required'],
 )
-@ShouldThrow(
-  'Uh...',
-  configurations: ['vague'],
-  element: false,
-)
+@ShouldThrow('Uh...', configurations: ['vague'], element: false)
 @TestAnnotation()
 class TestClassFilePartOf {}
 
@@ -51,11 +39,7 @@ class TestClassFilePartOf {}
   partOfCurrent: true,
   configurations: ['default', 'no-prefix-required'],
 )
-@ShouldThrow(
-  'Uh...',
-  configurations: ['vague'],
-  element: false,
-)
+@ShouldThrow('Uh...', configurations: ['vague'], element: false)
 @TestAnnotation()
 class TestClassFilePartOfCurrent {}
 
@@ -74,11 +58,7 @@ const BadTestClassNameLowerCase = 'badtestclass';
   configurations: ['default'],
   expectedLogItems: ['This member might be not good.'],
 )
-@ShouldThrow(
-  'Uh...',
-  configurations: ['vague'],
-  element: false,
-)
+@ShouldThrow('Uh...', configurations: ['vague'], element: false)
 @TestAnnotation()
 class BadTestClass {}
 
@@ -98,11 +78,7 @@ class TestClassWithBadMember {
   'Only supports annotated classes.',
   todo: 'Remove `TestAnnotation` from the associated element.',
 )
-@ShouldThrow(
-  'Uh...',
-  configurations: ['vague'],
-  element: false,
-)
+@ShouldThrow('Uh...', configurations: ['vague'], element: false)
 @TestAnnotation()
 int badTestFunc() => 42;
 
@@ -110,10 +86,6 @@ int badTestFunc() => 42;
   'Only supports annotated classes.',
   todo: 'Remove `TestAnnotation` from the associated element.',
 )
-@ShouldThrow(
-  'Uh...',
-  configurations: ['vague'],
-  element: false,
-)
+@ShouldThrow('Uh...', configurations: ['vague'], element: false)
 @TestAnnotation()
 const badTestField = 42;

--- a/test/src/test_part.dart
+++ b/test/src/test_part.dart
@@ -1,16 +1,10 @@
 part of 'test_library.dart';
 
-@ShouldGenerate(
-  r'''
+@ShouldGenerate(r'''
 const TestClass2NameLength = 10;
 
 const TestClass2NameLowerCase = 'testclass2';
-''',
-)
-@ShouldThrow(
-  'Uh...',
-  configurations: ['vague'],
-  element: false,
-)
+''')
+@ShouldThrow('Uh...', configurations: ['vague'], element: false)
 @TestAnnotation()
 class TestClass2 {}

--- a/test/test_generator.dart
+++ b/test/test_generator.dart
@@ -31,8 +31,9 @@ class TestGenerator extends GeneratorForAnnotation<TestAnnotation> {
 
     // ignore: deprecated_member_use
     if (element is ClassElement) {
-      final unsupportedFunc = element.methods
-          .firstWhereOrNull((me) => me.name.contains('unsupported'));
+      final unsupportedFunc = element.methods.firstWhereOrNull(
+        (me) => me.name.contains('unsupported'),
+      );
 
       if (unsupportedFunc != null) {
         throw InvalidGenerationSourceError(


### PR DESCRIPTION
The default behaviour changed, `readAllSourcesFromFilesystem` gets it back.

This is because files have to be loaded before the build starts, there is no longer a test reader that lazily looks up files on the filesystem. So the default is now to _not_ read all the files as it would be excessive for most tests :)