### PR TITLE
feat!: drop mirrors, etc

### DIFF
--- a/lib/src/expectation_element.dart
+++ b/lib/src/expectation_element.dart
@@ -66,9 +66,12 @@ List<ExpectationElement> genAnnotatedElements(
 }
 
 const _mappers = {
-  TypeChecker.fromRuntime(ShouldGenerate): _shouldGenerate,
-  TypeChecker.fromRuntime(ShouldGenerateFile): _shouldGenerateFile,
-  TypeChecker.fromRuntime(ShouldThrow): _shouldThrow,
+  TypeChecker.typeNamed(ShouldGenerate, inPackage: 'source_gen_test'):
+      _shouldGenerate,
+  TypeChecker.typeNamed(ShouldGenerateFile, inPackage: 'source_gen_test'):
+      _shouldGenerateFile,
+  TypeChecker.typeNamed(ShouldThrow, inPackage: 'source_gen_test'):
+      _shouldThrow,
 };
 
 Iterable<TestExpectation> _expectationElements(Element2 element) sync* {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,12 +10,12 @@ environment:
 
 dependencies:
   analyzer: '>=7.4.0 <9.0.0'
-  build: ^3.0.0
+  build: '>=3.0.0 <5.0.0'
   build_test: ^3.3.0
   dart_style: ^3.0.0
   meta: ^1.15.0
   path: ^1.9.0
-  source_gen: ^3.0.0
+  source_gen: '>=3.1.0 <5.0.0'
   test: ^1.25.9
 
 dev_dependencies:


### PR DESCRIPTION
Fixes #91.

Depends on https://github.com/dart-lang/source_gen/pull/786.

dart analyze currently passes both flutter pub upgrade/downgrade.