### PR TITLE
test: migrate test suite to package:checks

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,5 +19,6 @@ dependencies:
   test: ^1.27.0
 
 dev_dependencies:
+  checks: ^0.3.1
   collection: ^1.19.0
   dart_flutter_team_lints: ^3.0.0

--- a/test/build_log_tracking_test.dart
+++ b/test/build_log_tracking_test.dart
@@ -1,11 +1,12 @@
+import 'package:checks/checks.dart';
 import 'package:source_gen_test/src/build_log_tracking.dart';
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 
 void main() {
   group('after calling initializeBuildLogTracking', () {
     initializeBuildLogTracking();
     test('calling init again throws', () {
-      expect(initializeBuildLogTracking, throwsStateError);
+      check(initializeBuildLogTracking).throws<StateError>();
     });
 
     // TODO: actually test something
@@ -14,11 +15,11 @@ void main() {
 
   group('without calling initializeBuildLogTracking', () {
     test('accessing buildLogItems throws', () {
-      expect(() => buildLogItems, throwsStateError);
+      check(() => buildLogItems).throws<StateError>();
     });
 
     test('calling clearBuildLog throws', () {
-      expect(clearBuildLog, throwsStateError);
+      check(clearBuildLog).throws<StateError>();
     });
   });
 }

--- a/test/generate_for_element_test.dart
+++ b/test/generate_for_element_test.dart
@@ -1,9 +1,10 @@
+import 'package:checks/checks.dart';
+import 'package:source_gen/source_gen.dart';
 import 'package:source_gen_test/src/build_log_tracking.dart';
 import 'package:source_gen_test/src/generate_for_element.dart';
 import 'package:source_gen_test/src/init_library_reader.dart';
-import 'package:source_gen_test/src/matchers.dart';
 import 'package:source_gen_test/src/test_annotated_classes.dart';
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 
 import 'test_generator.dart';
 
@@ -27,14 +28,19 @@ class TestClass{}
         'annotations.dart': _testAnnotationContent,
       }, 'bad_lib.dart');
 
-      expect(
+      final error = check(
         () => testAnnotatedElements(badReader, const TestGenerator()),
-        throwsInvalidGenerationSourceError(
-          'There are multiple annotations for these configurations: "c".',
-          todoMatcher:
-              'Ensure each configuration is only represented once per member.',
-        ),
-      );
+      ).throws<InvalidGenerationSourceError>();
+      error
+          .has((e) => e.message, 'message')
+          .equals(
+            'There are multiple annotations for these configurations: "c".',
+          );
+      error
+          .has((e) => e.todo, 'todo')
+          .equals(
+            'Ensure each configuration is only represented once per member.',
+          );
     });
 
     test('annotation with no configuration', () async {
@@ -49,13 +55,13 @@ class EmptyConfig{}
         'annotations.dart': _testAnnotationContent,
       }, 'bad_lib.dart');
 
-      expect(
+      final error = check(
         () => testAnnotatedElements(badReader, const TestGenerator()),
-        throwsInvalidGenerationSourceError(
-          '`configuration` cannot be empty.',
-          todoMatcher: 'Leave it `null`.',
-        ),
-      );
+      ).throws<InvalidGenerationSourceError>();
+      error
+          .has((e) => e.message, 'message')
+          .equals('`configuration` cannot be empty.');
+      error.has((e) => e.todo, 'todo').equals('Leave it `null`.');
     });
   });
 
@@ -72,7 +78,7 @@ class EmptyConfig{}
         'TestClass1',
       );
       printOnFailure(output);
-      expect(output, r'''
+      check(output).equals(r'''
 const TestClass1NameLength = 10;
 
 const TestClass1NameLowerCase = 'testclass1';
@@ -86,7 +92,7 @@ const TestClass1NameLowerCase = 'testclass1';
         'TestClass2',
       );
       printOnFailure(output);
-      expect(output, r'''
+      check(output).equals(r'''
 const TestClass2NameLength = 10;
 
 const TestClass2NameLowerCase = 'testclass2';
@@ -95,13 +101,18 @@ const TestClass2NameLowerCase = 'testclass2';
   });
 
   test('throwsInvalidGenerationSourceError', () async {
-    await expectLater(
-      () => generateForElement(const TestGenerator(), reader, 'BadTestClass'),
-      throwsInvalidGenerationSourceError(
-        'All classes must start with `TestClass`.',
-        todoMatcher:
-            'Rename the type or remove the `TestAnnotation` from class.',
-      ),
+    await check(
+      generateForElement(const TestGenerator(), reader, 'BadTestClass'),
+    ).throws<InvalidGenerationSourceError>(
+      (it) => it
+        ..has(
+          (e) => e.message,
+          'message',
+        ).equals('All classes must start with `TestClass`.')
+        ..has(
+          (e) => e.todo,
+          'todo',
+        ).equals('Rename the type or remove the `TestAnnotation` from class.'),
     );
   });
 
@@ -151,7 +162,7 @@ const TestClass2NameLowerCase = 'testclass2';
           expectedAnnotatedTests: validExpectedAnnotatedTests,
         );
 
-        expect(list, hasLength(25));
+        check(list).length.equals(25);
       });
 
       test('valid configuration', () {
@@ -163,7 +174,7 @@ const TestClass2NameLowerCase = 'testclass2';
           defaultConfiguration: ['default', 'no-prefix-required', 'vague'],
         );
 
-        expect(list, hasLength(25));
+        check(list).length.equals(25);
       });
 
       test('different defaultConfiguration', () {
@@ -175,7 +186,7 @@ const TestClass2NameLowerCase = 'testclass2';
           defaultConfiguration: ['default'],
         );
 
-        expect(list, hasLength(22));
+        check(list).length.equals(22);
       });
 
       test('different defaultConfiguration', () {
@@ -187,24 +198,25 @@ const TestClass2NameLowerCase = 'testclass2';
           defaultConfiguration: ['no-prefix-required'],
         );
 
-        expect(list, hasLength(22));
+        check(list).length.equals(22);
       });
     });
     group('defaultConfiguration', () {
       test('empty', () {
-        expect(
+        _checkArgumentError(
           () => testAnnotatedElements(
             reader,
             const TestGenerator(),
             additionalGenerators: validAdditionalGenerators,
             defaultConfiguration: [],
           ),
-          _throwsArgumentError('Cannot be empty.', 'defaultConfiguration'),
+          'Cannot be empty.',
+          'defaultConfiguration',
         );
       });
 
       test('unknown item', () {
-        expect(
+        _checkArgumentError(
           () => testAnnotatedElements(
             reader,
             const TestGenerator(),
@@ -215,18 +227,16 @@ const TestClass2NameLowerCase = 'testclass2';
             },
             defaultConfiguration: ['unknown'],
           ),
-          _throwsArgumentError(
-            'Contains values not associated with provided generators: '
-                '"unknown".',
-            'defaultConfiguration',
-          ),
+          'Contains values not associated with provided generators: '
+              '"unknown".',
+          'defaultConfiguration',
         );
       });
     });
 
     group('expectedAnnotatedTests', () {
       test('too many', () {
-        expect(
+        _checkArgumentError(
           () => testAnnotatedElements(
             reader,
             const TestGenerator(),
@@ -237,31 +247,27 @@ const TestClass2NameLowerCase = 'testclass2';
               'extra',
             ],
           ),
-          _throwsArgumentError(
-            'There are unexpected items',
-            'expectedAnnotatedTests',
-          ),
+          'There are unexpected items',
+          'expectedAnnotatedTests',
         );
       });
 
       test('too few', () {
-        expect(
+        _checkArgumentError(
           () => testAnnotatedElements(
             reader,
             const TestGenerator(),
             expectedAnnotatedTests: ['TestClass1', 'TestClass2'],
           ),
-          _throwsArgumentError(
-            'There are items missing',
-            'expectedAnnotatedTests',
-          ),
+          'There are items missing',
+          'expectedAnnotatedTests',
         );
       });
     });
 
     group('additionalGenerators', () {
       test('unused generator fails', () {
-        expect(
+        _checkArgumentError(
           () => testAnnotatedElements(
             reader,
             const TestGenerator(),
@@ -278,35 +284,31 @@ const TestClass2NameLowerCase = 'testclass2';
             // 'vague' is excluded here!
             defaultConfiguration: ['default', 'no-prefix-required'],
           ),
-          _throwsArgumentError(
-            'Some of the specified generators were not used for their '
-            'corresponding configurations: "extra".\n'
-            'Remove the entry from `additionalGenerators` or update '
-            '`defaultConfiguration`.',
-          ),
+          'Some of the specified generators were not used for their '
+          'corresponding configurations: "extra".\n'
+          'Remove the entry from `additionalGenerators` or update '
+          '`defaultConfiguration`.',
         );
       });
 
       test('missing a specified generator fails', () {
-        expect(
+        _checkArgumentError(
           () => testAnnotatedElements(reader, const TestGenerator()),
-          _throwsArgumentError(
-            'There are elements defined with configurations with no '
-            'associated generator provided.\n'
-            '`BadTestClass`: "no-prefix-required", "vague"; '
-            '`TestClass1`: "no-prefix-required", "vague"; '
-            '`TestClass2`: "vague"; '
-            '`TestClassFileNoPart`: "no-prefix-required", "vague"; '
-            '`TestClassFilePartOf`: "no-prefix-required", "vague"; '
-            '`TestClassFilePartOfCurrent`: "no-prefix-required", "vague"; '
-            '`badTestField`: "vague"; '
-            '`badTestFunc`: "vague"',
-          ),
+          'There are elements defined with configurations with no '
+          'associated generator provided.\n'
+          '`BadTestClass`: "no-prefix-required", "vague"; '
+          '`TestClass1`: "no-prefix-required", "vague"; '
+          '`TestClass2`: "vague"; '
+          '`TestClassFileNoPart`: "no-prefix-required", "vague"; '
+          '`TestClassFilePartOf`: "no-prefix-required", "vague"; '
+          '`TestClassFilePartOfCurrent`: "no-prefix-required", "vague"; '
+          '`badTestField`: "vague"; '
+          '`badTestFunc`: "vague"',
         );
       });
 
       test('key "default" not allowed', () {
-        expect(
+        _checkArgumentError(
           () => testAnnotatedElements(
             reader,
             const TestGenerator(),
@@ -314,15 +316,13 @@ const TestClass2NameLowerCase = 'testclass2';
               'default': TestGenerator(requireTestClassPrefix: false),
             },
           ),
-          _throwsArgumentError(
-            'Contained an unsupported key "default".',
-            'additionalGenerators',
-          ),
+          'Contained an unsupported key "default".',
+          'additionalGenerators',
         );
       });
 
       test('key "" not allowed', () {
-        expect(
+        _checkArgumentError(
           () => testAnnotatedElements(
             reader,
             const TestGenerator(),
@@ -330,18 +330,25 @@ const TestClass2NameLowerCase = 'testclass2';
               '': TestGenerator(requireTestClassPrefix: false),
             },
           ),
-          _throwsArgumentError(
-            'Contained an unsupported key "".',
-            'additionalGenerators',
-          ),
+          'Contained an unsupported key "".',
+          'additionalGenerators',
         );
       });
     });
   });
 }
 
-Matcher _throwsArgumentError(Object? matcher, [String? name]) => throwsA(
-  isArgumentError
-      .having((e) => e.message, 'message', matcher)
-      .having((ae) => ae.name, 'name', name),
-);
+void _checkArgumentError(
+  void Function() callback,
+  String expectedMessagePart, [
+  String? expectedName,
+]) {
+  final error = check(callback).throws<ArgumentError>();
+  error
+      .has((e) => e.message, 'message')
+      .isA<String>()
+      .contains(expectedMessagePart);
+  if (expectedName != null) {
+    error.has((e) => e.name, 'name').equals(expectedName);
+  }
+}

--- a/test/generate_for_element_test.dart
+++ b/test/generate_for_element_test.dart
@@ -28,19 +28,15 @@ class TestClass{}
         'annotations.dart': _testAnnotationContent,
       }, 'bad_lib.dart');
 
-      final error = check(
-        () => testAnnotatedElements(badReader, const TestGenerator()),
-      ).throws<InvalidGenerationSourceError>();
-      error
-          .has((e) => e.message, 'message')
-          .equals(
-            'There are multiple annotations for these configurations: "c".',
-          );
-      error
-          .has((e) => e.todo, 'todo')
-          .equals(
-            'Ensure each configuration is only represented once per member.',
-          );
+      check(
+          () => testAnnotatedElements(badReader, const TestGenerator()),
+        ).throws<InvalidGenerationSourceError>()
+        ..has((e) => e.message, 'message').equals(
+          'There are multiple annotations for these configurations: "c".',
+        )
+        ..has((e) => e.todo, 'todo').equals(
+          'Ensure each configuration is only represented once per member.',
+        );
     });
 
     test('annotation with no configuration', () async {
@@ -55,13 +51,14 @@ class EmptyConfig{}
         'annotations.dart': _testAnnotationContent,
       }, 'bad_lib.dart');
 
-      final error = check(
-        () => testAnnotatedElements(badReader, const TestGenerator()),
-      ).throws<InvalidGenerationSourceError>();
-      error
-          .has((e) => e.message, 'message')
-          .equals('`configuration` cannot be empty.');
-      error.has((e) => e.todo, 'todo').equals('Leave it `null`.');
+      check(
+          () => testAnnotatedElements(badReader, const TestGenerator()),
+        ).throws<InvalidGenerationSourceError>()
+        ..has(
+          (e) => e.message,
+          'message',
+        ).equals('`configuration` cannot be empty.')
+        ..has((e) => e.todo, 'todo').equals('Leave it `null`.');
     });
   });
 
@@ -343,11 +340,11 @@ void _checkArgumentError(
   String expectedMessagePart, [
   String? expectedName,
 ]) {
-  final error = check(callback).throws<ArgumentError>();
-  error
-      .has((e) => e.message, 'message')
-      .isA<String>()
-      .contains(expectedMessagePart);
+  final error = check(callback).throws<ArgumentError>()
+    ..has(
+      (e) => e.message,
+      'message',
+    ).isA<String>().contains(expectedMessagePart);
   if (expectedName != null) {
     error.has((e) => e.name, 'name').equals(expectedName);
   }

--- a/test/init_library_reader_test.dart
+++ b/test/init_library_reader_test.dart
@@ -1,8 +1,9 @@
 import 'dart:io';
 
 import 'package:build/build.dart';
+import 'package:checks/checks.dart';
 import 'package:source_gen_test/src/init_library_reader.dart';
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 
 // TODO: test initializeLibraryReader - but since
 //  `initializeLibraryReaderForDirectory` wraps it, not a big hurry
@@ -14,64 +15,55 @@ void main() {
         'test_library.dart',
       );
 
-      expect(reader.directory, 'test/src');
-      expect(reader.fileName, 'test_library.dart');
-      expect(
-        reader.allElements.map((e) => e.toString()),
-        unorderedMatches([
-          'library package:__test__/test_library.dart',
-          'int get badTestField',
-          'class TestClass1',
-          'class TestClassFileNoPart',
-          'class TestClassFilePartOf',
-          'class TestClassFilePartOfCurrent',
-          'class BadTestClass',
-          'class TestClassWithBadMember',
-          'int badTestFunc()',
-          'int badTestField',
-          'class TestClass2',
-        ]),
-      );
+      check(reader.directory).equals('test/src');
+      check(reader.fileName).equals('test_library.dart');
+      check(reader.allElements.map((e) => e.toString())).unorderedEquals([
+        'library package:__test__/test_library.dart',
+        'int get badTestField',
+        'class TestClass1',
+        'class TestClassFileNoPart',
+        'class TestClassFilePartOf',
+        'class TestClassFilePartOfCurrent',
+        'class BadTestClass',
+        'class TestClassWithBadMember',
+        'int badTestFunc()',
+        'int badTestField',
+        'class TestClass2',
+      ]);
     });
 
     test('bad library name', () async {
-      await expectLater(
-        () => initializeLibraryReaderForDirectory(
+      await check(
+        initializeLibraryReaderForDirectory(
           'test/src',
           'test_library_bad.dart',
         ),
-        throwsA(
-          isArgumentError
-              .having(
-                (ae) => ae.message,
-                'message',
-                'Must exist as a file in `sourceDirectory`.',
-              )
-              .having((ae) => ae.name, 'name', 'targetLibraryFileName'),
-        ),
+      ).throws<ArgumentError>(
+        (it) => it
+          ..has(
+            (ae) => ae.message,
+            'message',
+          ).equals('Must exist as a file in `sourceDirectory`.')
+          ..has((ae) => ae.name, 'name').equals('targetLibraryFileName'),
       );
     });
 
     test('non-existant directory', () async {
-      await expectLater(
-        () => initializeLibraryReaderForDirectory(
+      await check(
+        initializeLibraryReaderForDirectory(
           'test/not_src',
           'test_library.dart',
         ),
-        throwsA(const TypeMatcher<FileSystemException>()),
-      );
+      ).throws<FileSystemException>();
     });
 
     test('part instead', () async {
-      await expectLater(
-        () => initializeLibraryReaderForDirectory('test/src', 'test_part.dart'),
-        throwsA(
-          isA<NonLibraryAssetException>().having(
-            (ae) => ae.assetId.toString(),
-            'assetId.toString()',
-            '__test__|lib/test_part.dart',
-          ),
-        ),
+      await check(
+        initializeLibraryReaderForDirectory('test/src', 'test_part.dart'),
+      ).throws<NonLibraryAssetException>(
+        (it) => it
+            .has((ae) => ae.assetId.toString(), 'assetId.toString()')
+            .equals('__test__|lib/test_part.dart'),
       );
     });
   });


### PR DESCRIPTION
Migrates the test suite from `package:matcher` to `package:checks`.

Verified 100% clean static analysis (`dart analyze`) and all tests passing (`dart test`).